### PR TITLE
Re-order dependencies for SimpleTest

### DIFF
--- a/commerce_kickstart.info
+++ b/commerce_kickstart.info
@@ -31,6 +31,13 @@ dependencies[] = rules_admin
 dependencies[] = views
 dependencies[] = views_ui
 
+; Install contrib dependencies
+dependencies[] = date
+dependencies[] = date_popup
+dependencies[] = date_api
+dependencies[] = message
+dependencies[] = message_notify
+
 ; Install the Commerce modules.
 dependencies[] = commerce
 dependencies[] = commerce_ui
@@ -40,6 +47,7 @@ dependencies[] = commerce_customer
 dependencies[] = commerce_customer_ui
 dependencies[] = commerce_line_item
 dependencies[] = commerce_line_item_ui
+dependencies[] = commerce_price
 dependencies[] = commerce_order
 dependencies[] = commerce_order_ui
 dependencies[] = commerce_payment
@@ -47,7 +55,6 @@ dependencies[] = commerce_payment_example
 dependencies[] = commerce_payment_ui
 dependencies[] = commerce_shipping
 dependencies[] = commerce_shipping_ui
-dependencies[] = commerce_price
 dependencies[] = commerce_product
 dependencies[] = commerce_product_ui
 dependencies[] = commerce_product_pricing


### PR DESCRIPTION
DrupalWebTestCase::setUp activates a profile's dependencies via
module_enable($profile_details['dependencies'], FALSE);

The "FALSE" means that only the specified modules will be enabled, and
only in the specified order. Since $profile_details['dependencies']
comes straight from the profile's .info file, that file needs to be
complete and in a valid order.

This change ensures that.
