### PR TITLE
Removed deprecated patch for rules

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -12,7 +12,6 @@ projects[entityreference][subdir] = "contrib"
 projects[entityreference][patch][] = "http://drupal.org/files/1580348-universal-formatters-17.patch"
 projects[rules][version] = 2.7
 projects[rules][subdir] = "contrib"
-projects[rules][patch][] = "http://drupal.org/files/issues/2120421-2-fix-events-inclusion-plana.patch"
 projects[views][version] = 3.8
 projects[views][subdir] = "contrib"
 projects[views][patch][] = "http://drupal.org/files/2059555-reduce-formatter-form-state.patch"


### PR DESCRIPTION
I broke the build. Did not notice that I left the patch which has been committed to Rules 2.7.
