### PR TITLE
Only enable commerce_payment_example if commerce_kickstart_payment is enabled

### DIFF
--- a/commerce_kickstart.install
+++ b/commerce_kickstart.install
@@ -1150,11 +1150,13 @@ function commerce_kickstart_update_7218() {
 }
 
 /**
- * Remove Commerce Kickstart payment example and enable Commerce payment example.
+ * Disable Commerce Kickstart payment example and enable Commerce payment example.
  */
 function commerce_kickstart_update_7219() {
-  _commerce_kickstart_disable_modules(array('commerce_kickstart_payment'));
-  module_enable(array('commerce_payment_example'));
+  if (module_exists('commerce_kickstart_payment')) {
+    _commerce_kickstart_disable_modules(array('commerce_kickstart_payment'));
+    module_enable(array('commerce_payment_example'));
+  }
 }
 
 /**


### PR DESCRIPTION
THIS SHOULD NOT BE COMMITTED YET. SEEMS THAT THE UPDATE TESTS FAILS.

Without this commerce payment example can be enabled without the user needing it.
