### PR TITLE
Add the new release of the Mailjet module

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -188,7 +188,7 @@ projects[kameleoon][version] = "1.1"
 projects[mailup][subdir] = "contrib"
 projects[mailup][version] = "1.1"
 projects[mailjet][subdir] = "contrib"
-projects[mailjet][version] = "2.1"
+projects[mailjet][version] = "2.2"
 
 ; Search related modules.
 projects[search_api][version] = 1.14


### PR DESCRIPTION
This new release of the mailjet module fixes an issue with displaying the add trusted domain form
