### PR TITLE
Remove Bean modules

### DIFF
--- a/commerce_kickstart.install
+++ b/commerce_kickstart.install
@@ -1165,3 +1165,10 @@ function commerce_kickstart_update_7220() {
   variable_set('chosen_minimum_single', 'Always Apply');
   variable_set('chosen_minimum_multiple', 'Always Apply');
 }
+
+/**
+ * Remove modules that are no longer used (bean, commerce_bean).
+ */
+function commerce_kickstart_update_7221() {
+  _commerce_kickstart_disable_modules(array('bean', 'commerce_bean'));
+}

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -93,8 +93,6 @@ projects[commerce_physical][download][revision] = e2a8866
 projects[commerce_physical][download][branch] = 7.x-1.x
 projects[commerce_amex][subdir] = "contrib"
 projects[commerce_amex][version] = 1.1
-projects[commerce_bean][subdir] = "contrib"
-projects[commerce_bean][version] = 1.0-beta1
 projects[commerce_cba][subdir] = "contrib"
 projects[commerce_cba][version] = 1.0-beta1
 projects[commerce_authnet][subdir] = "contrib"
@@ -115,8 +113,6 @@ projects[commerce_firstdata_gge4][version] = 1.0
 projects[commerce_firstdata_gge4][subdir] = "contrib"
 
 ; Other contribs.
-projects[bean][version] = 1.7
-projects[bean][subdir] = "contrib"
 projects[countries][version] = 2.3
 projects[countries][subdir] = "contrib"
 projects[remote_stream_wrapper][version] = 1.0-rc1


### PR DESCRIPTION
#93 continued.

I've decided to proceed with removing these modules, they were a dependency of a module that wasn't even installed by default. Beans are provided in code, so no data loss will occur, anyone using Bean can simply readd the module.
