### PR TITLE
refactor(Theme): Standardize Preprocess/Process Files

### DIFF
--- a/themes/commerce_kickstart_theme/preprocess/preprocess-html.inc
+++ b/themes/commerce_kickstart_theme/preprocess/preprocess-html.inc
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Preprocess variables for html.tpl.php
+ *
+ * @see system_elements()
+ * @see html.tpl.php
+ */
+function commerce_kickstart_theme_alpha_preprocess_html(&$variables) {
+  // Add conditional stylesheets for IE
+  drupal_add_css(path_to_theme() . '/css/commerce-kickstart-theme-ie-lte-8.css', array('group' => CSS_THEME, 'weight' => 23, 'browsers' => array('IE' => 'lte IE 8', '!IE' => FALSE), 'preprocess' => FALSE));
+  drupal_add_css(path_to_theme() . '/css/commerce-kickstart-theme-ie-lte-7.css', array('group' => CSS_THEME, 'weight' => 24, 'browsers' => array('IE' => 'lte IE 7', '!IE' => FALSE), 'preprocess' => FALSE));
+
+  // Add external libraries.
+  drupal_add_library('commerce_kickstart_theme', 'selectnav');
+}

--- a/themes/commerce_kickstart_theme/preprocess/preprocess-node.inc
+++ b/themes/commerce_kickstart_theme/preprocess/preprocess-node.inc
@@ -3,7 +3,7 @@
 /**
  * Override the submitted variable.
  */
-function commerce_kickstart_theme_preprocess_node(&$variables) {
+function commerce_kickstart_theme_alpha_preprocess_node(&$variables) {
   $variables['submitted'] = $variables['date'] . ' - ' . $variables['name'];
   if ($variables['type'] == 'blog_post') {
     $variables['submitted'] = t('By') . ' ' . $variables['name'] . ', ' . $variables['date'];

--- a/themes/commerce_kickstart_theme/preprocess/preprocess-node.inc
+++ b/themes/commerce_kickstart_theme/preprocess/preprocess-node.inc
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Override the submitted variable.
+ */
+function commerce_kickstart_theme_preprocess_node(&$variables) {
+  $variables['submitted'] = $variables['date'] . ' - ' . $variables['name'];
+  if ($variables['type'] == 'blog_post') {
+    $variables['submitted'] = t('By') . ' ' . $variables['name'] . ', ' . $variables['date'];
+  }
+}

--- a/themes/commerce_kickstart_theme/template.php
+++ b/themes/commerce_kickstart_theme/template.php
@@ -1,21 +1,6 @@
 <?php
 
 /**
- * Preprocess variables for html.tpl.php
- *
- * @see system_elements()
- * @see html.tpl.php
- */
-function commerce_kickstart_theme_preprocess_html(&$variables) {
-  // Add conditional stylesheets for IE
-  drupal_add_css(path_to_theme() . '/css/commerce-kickstart-theme-ie-lte-8.css', array('group' => CSS_THEME, 'weight' => 23, 'browsers' => array('IE' => 'lte IE 8', '!IE' => FALSE), 'preprocess' => FALSE));
-  drupal_add_css(path_to_theme() . '/css/commerce-kickstart-theme-ie-lte-7.css', array('group' => CSS_THEME, 'weight' => 24, 'browsers' => array('IE' => 'lte IE 7', '!IE' => FALSE), 'preprocess' => FALSE));
-
-  // Add external libraries.
-  drupal_add_library('commerce_kickstart_theme', 'selectnav');
-}
-
-/**
  * Implements hook_library().
  */
 function commerce_kickstart_theme_library() {
@@ -27,14 +12,4 @@ function commerce_kickstart_theme_library() {
     ),
   );
   return $libraries;
-}
-
-/**
- * Override the submitted variable.
- */
-function commerce_kickstart_theme_preprocess_node(&$variables) {
-  $variables['submitted'] = $variables['date'] . ' - ' . $variables['name'];
-  if ($variables['type'] == 'blog_post') {
-    $variables['submitted'] = t('By') . ' ' . $variables['name'] . ', ' . $variables['date'];
-  }
 }


### PR DESCRIPTION
Moves the preprocess functions from inside template.php into their own files to keep with the recommendations of the theme.  A minor nitpick, but if the functionality is there and some functions use their own preprocess files, maybe they all should?