### PR TITLE
Updated contrib module versions in drupal-org.make to new stable versions, Drupal core version, and Travis version matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ mysql:
 
 env:
   - UPGRADE=none
+  - UPGRADE=7.x-2.45
+  - UPGRADE=7.x-2.44
   - UPGRADE=7.x-2.43
   - UPGRADE=7.x-2.42
   - UPGRADE=7.x-2.41
@@ -26,8 +28,6 @@ env:
   - UPGRADE=7.x-2.35
   - UPGRADE=7.x-2.34
   - UPGRADE=7.x-2.33
-  - UPGRADE=7.x-2.32
-  - UPGRADE=7.x-2.31
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ mysql:
 
 env:
   - UPGRADE=none
+  - UPGRADE=7.x-2.46
   - UPGRADE=7.x-2.45
   - UPGRADE=7.x-2.44
   - UPGRADE=7.x-2.43
@@ -27,7 +28,6 @@ env:
   - UPGRADE=7.x-2.36
   - UPGRADE=7.x-2.35
   - UPGRADE=7.x-2.34
-  - UPGRADE=7.x-2.33
 
 matrix:
   fast_finish: true

--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,6 +1,6 @@
 api = 2
 core = 7.x
-projects[drupal][version] = 7.54
+projects[drupal][version] = 7.55
 
 ; Patches for Core
 projects[drupal][patch][] = "http://drupal.org/files/issues/install-redirect-on-empty-database-728702-36.patch"

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -7,9 +7,9 @@ defaults[projects][subdir] = contrib
 ; Basic contributed modules.
 projects[ctools][version] = 1.12
 projects[entity][version] = 1.8
-projects[entityreference][version] = 1.2
-projects[rules][version] = 2.9
-projects[views][version] = 3.15
+projects[entityreference][version] = 1.4
+projects[rules][version] = 2.10
+projects[views][version] = 3.16
 projects[views_bulk_operations][version] = 3.4
 projects[addressfield][version] = 1.2
 projects[features][version] = 2.10
@@ -68,7 +68,7 @@ projects[commerce_firstdata_gge4][version] = 1.1
 ; Other contribs.
 projects[countries][version] = 2.3
 projects[remote_stream_wrapper][version] = 1.0-rc1
-projects[colorbox][version] = 2.12
+projects[colorbox][version] = 2.13
 projects[physical][version] = 1.0
 projects[crumbs][version] = 1.10
 projects[http_client][version] = 2.4
@@ -85,7 +85,7 @@ projects[service_links]download][branch] = 7.x-2.x
 projects[advanced_help][version] = 1.3
 projects[mailsystem][version] = 2.34
 projects[mailsystem][patch][1534706] = "https://www.drupal.org/files/mailsystem.1534706.6.patch"
-projects[mimemail][version] = 1.0-beta4
+projects[mimemail][version] = 1.0
 projects[token][version] = 1.7
 projects[token][patch][] = "http://drupal.org/files/token-token_asort_tokens-1712336_0.patch"
 projects[eva][version] = 1.3
@@ -94,14 +94,14 @@ projects[message_notify][version] = 2.5
 projects[migrate][version] = 2.8
 projects[migrate_extras][version] = 2.5
 projects[migrate_extras][patch][] = "http://drupal.org/files/migrate_extras-fix-destid2-array-1951904-4.patch"
-projects[date][version] = 2.9
+projects[date][version] = 2.10
 projects[yottaa][version] = 1.2
 projects[menu_attributes][version] = 1.0
 projects[fences][version] = 1.2
 projects[title][version] = 1.0-alpha9
 projects[kameleoon][version] = 1.1
 projects[mailup][version] = 1.4
-projects[mailjet][version] = 2.12
+projects[mailjet][version] = 2.13
 
 ; Search related modules.
 projects[search_api][version] = 1.21
@@ -123,17 +123,14 @@ projects[cloud_zoom][download][type] = git
 projects[cloud_zoom][download][revision] = 3cff30f
 projects[cloud_zoom][download][branch] = 7.x-1.x
 projects[special_menu_items][version] = 2.0
-projects[chosen][version] = 2.x-dev
-projects[chosen][download][type] = git
-projects[chosen][download][revision] = e7a0d22
-projects[chosen][download][branch] = 7.x-2.x
+projects[chosen][version] = 2.1
 projects[admin_views][version] = 1.6
 projects[distro_update][version] = 1.0-beta4
 
 ; Internationalization
 projects[variable][version] = 2.5
-projects[i18n][version] = 1.15
-projects[lingotek][version] = 7.19
+projects[i18n][version] = 1.17
+projects[lingotek][version] = 7.21
 
 ; Base theme.
 projects[omega][version] = 3.1

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -101,7 +101,7 @@ projects[fences][version] = 1.2
 projects[title][version] = 1.0-alpha9
 projects[kameleoon][version] = 1.1
 projects[mailup][version] = 1.4
-projects[mailjet][version] = 2.13
+projects[mailjet][version] = 2.14
 
 ; Search related modules.
 projects[search_api][version] = 1.21
@@ -114,7 +114,7 @@ projects[facetapi][patch][2378693] = "https://www.drupal.org/files/issues/notice
 projects[search_api_sorts][version] = 1.7
 
 ; UI improvement modules.
-projects[module_filter][version] = 2.0
+projects[module_filter][version] = 2.1
 projects[image_delta_formatter][version] = 1.0-rc1
 projects[link][version] = 1.4
 projects[pathauto][version] = 1.3


### PR DESCRIPTION
Hey @bojanz & @mglaman,

Couple more recent module updates, and [Drupal core 7.55](https://www.drupal.org/project/drupal/releases/7.55).