### PR TITLE
Package updates by Centarro Update Assistant

### DIFF
--- a/drupal-org-core.make
+++ b/drupal-org-core.make
@@ -1,6 +1,6 @@
 api = 2
 core = 7.x
-projects[drupal][version] = 7.66
+projects[drupal][version] = 7.67
 
 ; Patches for Core
 projects[drupal][patch][728702] = "http://drupal.org/files/issues/install-redirect-on-empty-database-728702-36.patch"


### PR DESCRIPTION
The following dependencies were updated:
- drupal/drupal (7.67)